### PR TITLE
Bugfix tcpdf_images.php - PHP 7.4

### DIFF
--- a/src/LynX39/LaraPdfMerger/tcpdf/include/tcpdf_images.php
+++ b/src/LynX39/LaraPdfMerger/tcpdf/include/tcpdf_images.php
@@ -315,7 +315,7 @@ class TCPDF_IMAGES {
 					if ($n > 0) {
 						$trns = array();
 						for ($i = 0; $i < $n; ++ $i) {
-							$trns[] = ord($t{$i});
+							$trns[] = ord($t[$i]);
 						}
 					}
 				}


### PR DESCRIPTION
With PHP 7.4 I get the warning / error "Array and string offset access syntax with curly braces is deprecated"

Responsible is line 318 tcpdf_images.php, where it still uses the old syntax $t{$i} to access the array.

Replaced it with $t[$i]